### PR TITLE
Fix apt hook to check it /sbin/paxrat exists

### DIFF
--- a/etc/apt/apt.conf.d/70paxrat
+++ b/etc/apt/apt.conf.d/70paxrat
@@ -1,2 +1,2 @@
-DPkg::Post-Invoke { "/sbin/paxrat -c /etc/paxrat/paxrat.conf";}
+DPkg::Post-Invoke { "/usr/bin/test -x /sbin/paxrat && /sbin/paxrat -c /etc/paxrat/paxrat.conf || true";}
 

--- a/etc/apt/apt.conf.d/70paxrat
+++ b/etc/apt/apt.conf.d/70paxrat
@@ -1,2 +1,2 @@
-DPkg::Post-Invoke { "/usr/bin/test -x /sbin/paxrat && /sbin/paxrat -c /etc/paxrat/paxrat.conf || true";}
+DPkg::Post-Invoke { "/usr/bin/test -x /sbin/paxrat && /sbin/paxrat 1>/dev/null || true";}
 


### PR DESCRIPTION
`apt remove paxrat' ends up in error since /sbin/paxrat has been removed when the hook is called. This change should fix it.

See Debian Bug: https://bugs.debian.org/852086

Signed-off-by: Santiago Ruano Rincón <santiago@debian.org>